### PR TITLE
Edit requirements.txt to use the new package validata-table v0.10.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,4 +24,4 @@ WORKDIR /home/validata/
 COPY --chown=validata:validata requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt --no-warn-script-location
 
-CMD gunicorn --workers 4 --bind 0.0.0.0:5000 validata_api:app
+CMD gunicorn --workers 4 --bind 0.0.0.0:5000 validata_api.api:app

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,1 @@
-opening-hours-py==0.5.4
-validata-api==0.6.4
-gunicorn
+validata-table==0.10.1


### PR DESCRIPTION
As for validata.fr project, this pull request aims to use for Validata Table API the new package validata-table resulting from the migration of Validata Table project into the [new gitlab mono-repository validata-table](https://gitlab.com/validata-table/validata-table)

NB : It will need to update locally .env file to set FLASK_SECRET_KEY environment variable before deploy in preprod.